### PR TITLE
Update euclid to 0.22 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ members = [
     "surfman-chains-api",
     "surfman-chains",
 ]
+
+[patch.crates-io]
+# TODO(bryce): Remove this when the PR is merged: https://github.com/servo/surfman/pull/234
+surfman = { git = "https://github.com/Bryce-MW/surfman", branch = "euclid-update" }

--- a/surfman-chains/Cargo.toml
+++ b/surfman-chains/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surfman-chains"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Alan Jeffrey <ajeffrey@mozilla.com>"]
 edition = "2018"
 description = "An implementation of double-buffered swap chains for surfman"
@@ -11,9 +11,9 @@ repository = "https://github.com/asajeffrey/surfman-chains"
 path = "lib.rs"
 
 [dependencies]
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 log = "0.4"
 sparkle = "0.1"
 surfman-chains-api = "0.2"
-surfman = "0.4"
+surfman = "0.5"


### PR DESCRIPTION
Updating Euclid is a breaking change so that's why I bumped the version. No changes were needed to make the upgrade.

Note that this requires surfman to be updated as well. I have put in a patch for now but that can be removed when [the PR is merged](https://github.com/servo/surfman/pull/234).

This is part of my effort to update the version of webrender used by Servo. I have made [an issue on the Servo repository](https://github.com/servo/servo/issues/28585) to keep track.